### PR TITLE
Version v0.3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,25 +1,29 @@
 {
   "name": "mobify-client",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Tools for building and compiling mobify.js adaptations",
   "author": "Mobify <dev@mobify.com>",
+  "homepage": "http://www.mobifyjs.com",
+  "bugs": "https://github.com/mobify/mobify-client/issues",
   "dependencies": {
-    "request": "2.9.202",
+    "request": "2.11.4",
     "async": "0.1.22",
     "coffee-script": "1.3.3",
-    "commander": "0.6.1",
-    "fstream": "0.1.18",
+    "commander": "1.0.4",
+    "fstream": "0.1.19",
     "tar": "0.1.13",
-    "uglify-js": "1.3.1",
-    "clean-css": "0.4.1",
-    "wrench": "~1.3.9",
-    "connect": "2.3.4",
-    "express": "2.5.10"
+    "uglify-js": "1.3.3",
+    "clean-css": "0.6.0",
+    "wrench": "1.3.9",
+    "connect": "2.4.5",
+    "express": "2.5.11"
   },
   "devDependencies": {
-    "mocha": "1.2.1"
+    "mocha": "1.4.2"
   },
-  "engine": "node 0.6.2",
+  "engines": {
+    "node": ">=0.6.2"
+  },
   "main": "./lib/main.js",
   "bin": {
     "mobify": "./bin/mobify.js"
@@ -27,5 +31,6 @@
   "repository": {
     "type": "git",
     "url": "git@github.com:mobify/mobify-client.git"
-  }
+  },
+  "preferGlobal": true
 }


### PR DESCRIPTION
- Fixes encoding issues
- Updates dependencies

Tested on:

Node v0.6.3, v0.6.18, v0.8.2, v0.8.7, v0.8.9 on MacOSX
Node v0.8.9 on Windows XP
