### PR TITLE
Adds proxy option for pushing.

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -13,6 +13,7 @@ exports.post = post = (options, path, data, callback) ->
         headers:
             'Content-Length': dataBuffer.length
             'User-Agent': Utils.getUserAgent()
+        proxy: options.proxy || Utils.getProxy()
     
     request = Request opts, (err, response, body) ->
         if err

--- a/src/mobify.coffee
+++ b/src/mobify.coffee
@@ -32,6 +32,7 @@ program
     .option('-e, --endpoint <endpoint>', 'set the API endpoint eg. https://cloud.mobify.com/api/')
     .option('-u, --auth <auth>', 'username and API Key eg. username:apikey')
     .option('-p, --project <project>', 'override the project name in project.json for the push destination')
+    .option('-x, --proxy <proxy url>', 'use the specified proxy. URL in the format http://[username:password@]PROXY_HOST:PROXY_PORT/')
     .action Commands.push
 
 program

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -369,3 +369,11 @@ exports.compressJs = compressJs = (js) ->
     ast = Uglify.uglify.ast_mangle ast
     ast = Uglify.uglify.ast_squeeze ast
     Uglify.uglify.gen_code ast
+
+
+###
+Gets the system proxy
+
+###
+exports.getProxy = () ->
+    return process.env['http_proxy'] or process.env['HTTP_PROXY']


### PR DESCRIPTION
Adds ability to use a proxy while pushing.

Uses HTTP_PROXY, http_proxy or

```
  mobify push -x http://proxy:8888/
```

Does _not_ support proxy for tag injector
