### PR TITLE
Load custom tags with tag injector

### DIFF
--- a/src/injector.coffee
+++ b/src/injector.coffee
@@ -28,13 +28,17 @@ include = (klass, mixin) ->
 
 getTags = (opts, version) ->
     tags = {}
-    path = Path.join appSourceDir, 'vendor', 'tags', version + '/'
-    FS.readdirSync(path).forEach (filename) ->
-        if filename.indexOf('.html') is -1
-            return
+    if not isNaN(version) # if version is a number
+        path = Path.join appSourceDir, 'vendor', 'tags', version + '/'
+        FS.readdirSync(path).forEach (filename) ->
+            if filename.indexOf('.html') is -1
+                return
 
-        path = Path.join path, filename
-        tags[Path.basename filename, '.html'] = FS.readFileSync(path).toString()
+            path = Path.join path, filename
+            tags[Path.basename filename, '.html'] = FS.readFileSync(path).toString()
+    else # version is a path to a bootstrap tag
+        tags["bootstrap"] = FS.readFileSync(version).toString()
+        
     tags
 
 tag = (request, response, content, options) ->

--- a/src/mobify.coffee
+++ b/src/mobify.coffee
@@ -21,7 +21,7 @@ program
     .option('-a, --address <address>', 'address to bind to [0.0.0.0]', '0.0.0.0')
     .option('-m, --minify', 'enable minification')
     .option('-t, --tag', 'runs a tag injecting proxy, requires sudo')
-    .option('-u, --tag-version <version>', 'version of the tags to use [6]', '6')
+    .option('-u, --tag-version <version>', 'version of the tags to use [6], or a path to a bootstrap script', '6')
     .action Commands.preview
 
 program


### PR DESCRIPTION
Add ability to specify a path to a bootstrap tag, instead of only being able to reference a version number.
