### PR TITLE
Files excluded in project.json should no longer be uploaded

### DIFF
--- a/src/project.coffee
+++ b/src/project.coffee
@@ -84,7 +84,7 @@ class Project
                 callback null, @build_directory
                 return
 
-            tgz_stream = Utils.archive '.'
+            tgz_stream = Utils.archive '.', @exclude
             API.upload options, name, tgz_stream, callback
 
     save: (path='project.json') ->

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -277,13 +277,16 @@ Returns a .tgz stream from a folder.
 
 @param {String} path
 ###
-exports.archive = (path) ->
+exports.archive = (path, excludes) ->
     files = FStream.Reader 
         path: path
         type: "Directory"
         filter: () ->
             if (@type == 'File') and (@size >= 5*1000*1000)
                 console.log "File #{@path} (#{@size} bytes) exceeds 5MB maximum and will not be uploaded."
+                return false
+            if @basename in excludes
+                console.log "#{@path} was excluded from upload - excluded by project.json."
                 return false
             return !/^[.]/.test @basename
         mode: "0755"


### PR DESCRIPTION
- to cloud.mobify.com by the mobify push command.
