### PR TITLE
allow *.dust files as well as *.tmpl files for templates

### DIFF
--- a/lib/dust/duster.js
+++ b/lib/dust/duster.js
@@ -259,9 +259,9 @@ dust.emitRelativePartial = function(name, base, chunk, context) {
                 return chunk.partial(url, context).end();
             }
             
-            // .tmpl files are compiled into a template string and appended
+            // .tmpl and .dust files are compiled into a template string and appended
             // to the output so they can be used on the client side.
-            if (url.match(/([^\/\\]*)\.tmpl$/)) {
+            if (url.match(/([^\/\\]*)\.(tmpl|dust)$/)) {
                 var templateName = RegExp.$1
                   , source = pragmify(data, {whitespace: false})
                   , compiled;


### PR DESCRIPTION
I think *.dust files should be allowed as well. It automates syntax highlighting when available. Setting dust syntax highlighting for all *.tmpl by default can lead to conflicts with other projects that also use *.tmpl but not use dust.
This is mostly a convenience thing for Sublime Text, but i think it makes sense in general to allow *.dust files when working with Dust.js