### PR TITLE
Don't bind compass plugin twice

### DIFF
--- a/src/compass.coffee
+++ b/src/compass.coffee
@@ -6,8 +6,16 @@ COMPASS_PROC = if process.platform is 'win32'
 else
     "compass"
 
+# Setup compass plugin only the first time someone creates a server, not
+#   for ever server they create
+alreadyBound = false
+
 class CompassPlugin
     bindPreview: (preview_server) ->
+            if alreadyBound
+                return
+            else
+                alreadyBound = true
             console.log "Binding Compass Preview"
             
             ChildProcess.exec "#{COMPASS_PROC} clean", (err, stdout, stderr) ->


### PR DESCRIPTION
Status: **Ready for merge**

Reviewers: **@jansepar  @noahadams**
## Changes
- In the compass plugin, check to see if it has already been setup, if it has blow that popsicle stand.
## How to test-drive this PR
- Run this new version of the mobify plugin on a project that is using either 'compass_plugin' or 'compass_run'.
- When you run `mobify preview`, the message 'Binding Compass Preview' should only display once.
