### PR TITLE
Make client compatible with Node 0.12

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 v0.3.39 - Make mobify-client compatible with IO.js 1.1.0 and Node.js 0.12.x
-v0.3.38 - Re-enable iOS 8.0 scrollfix issue.
+v0.3.38 - Update 1.0, 1.1 and 1.3 with proper fix for iOS 8.0 scrolling
+          issue
 v0.3.37 - Revert updates to 1.0, 1.1 and 1.3 that attempted to fix an iOS 8.0
           scrolling bug but caused unintended side effects. A proper fix will
           be released shortly.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v0.3.39 - Make mobify-client compatible with IO.js 1.1.0 and Node.js 0.12.x
+v0.3.38 - Re-enable iOS 8.0 scrollfix issue.
 v0.3.37 - Revert updates to 1.0, 1.1 and 1.3 that attempted to fix an iOS 8.0
           scrolling bug but caused unintended side effects. A proper fix will
           be released shortly.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all:
 
 archive: 
 	git submodule update --init --recursive
-	git-archive-all --prefix='mobify-client/' tmp.tar 
+	git-archive-all --prefix='mobify-client/' tmp.tar
 	tar -xf tmp.tar
 	tar --exclude='*www*' -czhf mobify-client.`bin/mobify.js -V`.tgz mobify-client
 	rm -rf mobify-client;

--- a/lib/dust/server.js
+++ b/lib/dust/server.js
@@ -1,18 +1,10 @@
 var path = require('path'),
     parser = require('./parser'),
-    compiler = require('./compiler'),
-    Script = process.binding('evals').NodeScript;
-
-//require.paths.unshift(path.join(__dirname, '..'));
+    compiler = require('./compiler');
 
 module.exports = function(dust) {
   compiler.parse = parser.parse;
   dust.compile = compiler.compile;
-
-  /*dust.loadSource = function(source, path) {
-    var res = Script.runInNewContext(source, {dust: dust}, path);
-    return res;
-  };*/
 
   dust.nextTick = process.nextTick;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-client",
-  "version": "0.3.38",
+  "version": "0.3.39",
   "description": "Tools for building and compiling mobify.js adaptations",
   "author": "Mobify <dev@mobify.com>",
   "homepage": "http://www.mobifyjs.com",
@@ -11,7 +11,7 @@
     "coffee-script": "1.3.3",
     "commander": "1.0.4",
     "fstream": "0.1.19",
-    "tar": "0.1.16",
+    "tar": "1.0.3",
     "uglify-js": "1.3.3",
     "wrench": "1.3.9",
     "connect": "2.4.5",


### PR DESCRIPTION
Status: **Opened for visibility**
Reviewers: **@jansepar @scalvert @MikeKlemarewski**

## Changes
- Remove dead code in `lib/dust/server.js` that doesn't work in Node 0.12
- Updated `node-tar` dependency to remove engine version warning