### PR TITLE
RTM-91: Fix for Node 0.12.x on Windows

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -35,30 +35,7 @@ exports.post = post = (options, path, data, callback) ->
         
         callback null, response
 
-    writeThrottled = (buffer, destination, increment=32*1024, sleep=100) ->
-        if increment < buffer.length
-            endpoint = increment
-        else
-            endpoint = buffer.length
-
-        if endpoint == 0
-            destination.end()
-            return
-
-        sliced_buffer = buffer.slice 0, endpoint
-        destination.write sliced_buffer
-
-        remaining_buffer = buffer.slice endpoint, buffer.length
-
-        repeat = () ->
-            writeThrottled remaining_buffer, destination, increment, sleep
-
-        setTimeout repeat, sleep
-
-    if process.platform == 'win32'
-        writeThrottled dataBuffer, request
-    else
-        request.end dataBuffer
+    request.end dataBuffer
     
 
 exports.upload = upload = (options, project, stream, callback) ->


### PR DESCRIPTION
Status: **Ready for Review**
Reviewers: @fractaltheory @noahadams @jansepar @stewartyu 

## Jira Tickets:
- [x] [RTM-91](https://mobify.atlassian.net/browse/RTM-91)

## Todos:
- [ ] Engineer +1
- [x] Docs update
- [ ] Release Prep

### Feedback:
_none so far_

## Changes
- When pushing up a bundle, we used writeThrottled as a workaround for a Node on Windows SSL issue, it doesn't seem to be needed anymore. We can just use response.end.

## How to Test
- Verify that `mobify push` is broken on Windows when running a newer (0.12.x) version of Node
- Uninstall the old client
- Checkout this repo and branch, and update submodules (`git submodule update --recursive`), and then link it
- ???
- Profit!