### PR TITLE
Point to the correct 1.1.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
-v0.3.40 - Include Mobify.js 1.1.1 API, fix for Node 0.12.x on Windows
+v0.3.41 - Include Mobify.js 1.1.1 API, fix for Node 0.12.x on Windows
+          Note: v0.3.40 was unpublished.
 
 v0.3.39 - Make mobify-client compatible with IO.js 1.1.0 and Node.js 0.12.x
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-client",
-  "version": "0.3.40",
+  "version": "0.3.41",
   "description": "Tools for building and compiling mobify.js adaptations",
   "author": "Mobify <dev@mobify.com>",
   "homepage": "http://www.mobifyjs.com",


### PR DESCRIPTION
This PR fixes the SHA that the 1.1.1 vendor folder was pointing to.