### PR TITLE
Add mobifyjs v1.1.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,3 +38,7 @@
 	path = vendor/mobify-js/1.3.2/base
 	url = git@github.com:mobify/mobifyjs.git
 	branch = 1.3.2
+[submodule "vendor/mobify-js/1.1.4/base"]
+	path = vendor/mobify-js/1.1.4/base
+	url = git@github.com:mobify/mobifyjs.git
+	branch = 1.1.4

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-v0.3.44 - Includes Mobify.js 1.1.4, fix an SEO issue that incorrectly display
+v0.3.45 - Includes Mobify.js 1.1.4, fix an SEO issue that incorrectly display
           the mobify tag on SRP (Search Result Page)
 
 v0.3.44 - Includes Mobify.js 1.1.3 and 1.3.2 APIs, fix for a.js script path that

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v0.3.44 - Includes Mobify.js 1.1.4, fix an SEO issue that incorrectly display
+          the mobify tag on SRP (Search Result Page)
+
 v0.3.44 - Includes Mobify.js 1.1.3 and 1.3.2 APIs, fix for a.js script path that
           caused a HTTP 404 error when used with v7 Mobify tag
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-client",
-  "version": "0.3.44",
+  "version": "0.3.45",
   "description": "Tools for building and compiling mobify.js adaptations",
   "author": "Mobify <dev@mobify.com>",
   "homepage": "http://www.mobifyjs.com",


### PR DESCRIPTION
In order to do a release for mobifyjs, we need to release a new version for mobify-client. Because mobifyjs projects are built with mobify-client, not through npm packages.

TODO: 
- [x] wait for https://github.com/mobify/mobifyjs/pull/318 to merge
- [x] update the submodule commit to include the fix
- [ ] merge this PR
- [ ] do a npm release for mobify-client, target version 0.3.45