### PR TITLE
Release v0.3.46

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v0.3.46 - Update package "connect" to keep the compatibility with Node 4
+
 v0.3.45 - Includes Mobify.js 1.1.4, fix an SEO issue that incorrectly display
           the mobify tag on SRP (Search Result Page)
 

--- a/package.json
+++ b/package.json
@@ -6,17 +6,17 @@
   "homepage": "http://www.mobifyjs.com",
   "bugs": "https://github.com/mobify/mobify-client/issues",
   "dependencies": {
-    "request": "2.11.4",
     "async": "0.1.22",
+    "clean-css": "1.0.12",
     "coffee-script": "1.3.3",
     "commander": "1.0.4",
+    "connect": "^2.30.2",
+    "express": "2.5.11",
     "fstream": "0.1.19",
+    "request": "2.11.4",
     "tar": "1.0.3",
     "uglify-js": "1.3.3",
-    "wrench": "1.3.9",
-    "connect": "2.4.5",
-    "express": "2.5.11",
-    "clean-css": "1.0.12"
+    "wrench": "1.3.9"
   },
   "devDependencies": {
     "mocha": "1.4.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-client",
-  "version": "0.3.45",
+  "version": "0.3.46",
   "description": "Tools for building and compiling mobify.js adaptations",
   "author": "Mobify <dev@mobify.com>",
   "homepage": "http://www.mobifyjs.com",


### PR DESCRIPTION
Currently if a developer installs `mobify-client` and use Node 4. The client will break because the `connect` library uses a library called `debug` with version `*`, what this means is it will use the latest version of the library. The latest version of `debug` does not support Node 4 anymore by introducing ES6 syntax like `let`.

At this point, we want to keep the compatibility with Node 4 so nobody's work is interrupted.

Release a patch version to upgrade `connect` library.